### PR TITLE
Upgrade Android Gradle Plugin to version 7.3.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }


### PR DESCRIPTION
Android Studio Dolphin 2021.3.1 Patch 1 has been released, and with it Android Gradle Plugin 7.3.1