### PR TITLE
Make the encrypted database private inside the view model

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
         android:allowBackup="false"
         android:icon="@mipmap/icon"
         android:label="@string/app_name"
-        android:name=".App"
         android:roundIcon="@mipmap/icon_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyPeriodDataIsMine"

--- a/app/src/main/java/com/myperioddataismine/App.kt
+++ b/app/src/main/java/com/myperioddataismine/App.kt
@@ -1,7 +1,0 @@
-package com.myperioddataismine
-
-import android.app.Application
-
-class App: Application() {
-    val encryptedDatabase = EncryptedDatabase(this)
-}

--- a/app/src/main/java/com/myperioddataismine/MainActivity.kt
+++ b/app/src/main/java/com/myperioddataismine/MainActivity.kt
@@ -2,49 +2,94 @@ package com.myperioddataismine
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 
 class MainActivity : AppCompatActivity() {
     private val viewModel: MainViewModel by viewModels()
+    private var passcodeState = PasscodeState.None
+
+    private enum class PasscodeState {
+        None,
+        CreateDatabase,
+        DecryptDatabase
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
-        val encryptedDatabase = (application as App).encryptedDatabase
         if (savedInstanceState == null) {
-            supportFragmentManager.commit {
-                setReorderingAllowed(true)
-                if (encryptedDatabase.exists()) {
-                    replace<PasscodeFragment>(R.id.main_container)
-                } else {
-                    replace<WelcomeFragment>(R.id.main_container)
-                }
+            if (viewModel.encryptedDatabaseExists()) {
+                decryptDatabase()
+            } else {
+                welcome()
             }
         }
     }
 
+    private fun welcome() {
+        supportFragmentManager.commit {
+            setReorderingAllowed(true)
+            replace<WelcomeFragment>(R.id.main_container)
+        }
+    }
+
     fun getStarted() {
+        createDatabase()
+    }
+
+    private fun createDatabase() {
+        getPasscode(PasscodeState.CreateDatabase)
+    }
+
+    private fun decryptDatabase() {
+        getPasscode(PasscodeState.DecryptDatabase)
+    }
+
+    private fun getPasscode(passcodeState: PasscodeState) {
+        this.passcodeState = passcodeState
+        invalidateMenu()
+        val message = when (passcodeState) {
+            PasscodeState.CreateDatabase -> resources.getString(R.string.encrypt_text)
+            PasscodeState.DecryptDatabase -> resources.getString(R.string.decrypt_text)
+            PasscodeState.None -> throw Exception("Passcode state should never be None")
+        }
+        val bundle = Bundle()
+        bundle.putString("Message", message)
+        val passcodeFragment = PasscodeFragment()
+        passcodeFragment.arguments = bundle
         supportFragmentManager.commit {
             setReorderingAllowed(true)
-            replace<PasscodeFragment>(R.id.main_container)
+            replace(R.id.main_container, passcodeFragment)
         }
     }
 
-    fun databaseOpened() {
-        supportFragmentManager.commit {
-            setReorderingAllowed(true)
-            replace<UserDataViewFragment>(R.id.main_container)
+    fun tryPasscode(passcode: String) {
+        passcodeState = PasscodeState.None
+        if (viewModel.openDatabase(passcode)) {
+            viewUserData()
+        } else {
+            databaseErasePrompt()
         }
     }
 
-    fun getUserData(): UserData {
-        return viewModel.getUserData()
+    private fun databaseErasePrompt() {
+        AlertDialog.Builder(this)
+            .setTitle("Erase data?")
+            .setMessage("Unable to decrypt data!")
+            .setPositiveButton("Retry") { _, _ ->
+                decryptDatabase()
+            }
+            .setNegativeButton("Erase") { _, _ ->
+                viewModel.deleteDatabase()
+                createDatabase()
+            }
+            .show()
     }
 
-    fun saveUserData(userData: UserData) {
-        viewModel.saveUserData(userData)
+    private fun viewUserData() {
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace<UserDataViewFragment>(R.id.main_container)
@@ -56,5 +101,14 @@ class MainActivity : AppCompatActivity() {
             setReorderingAllowed(true)
             replace<UserDataEditFragment>(R.id.main_container)
         }
+    }
+
+    fun getUserData(): UserData {
+        return viewModel.getUserData()
+    }
+
+    fun saveUserData(userData: UserData) {
+        viewModel.saveUserData(userData)
+        viewUserData()
     }
 }

--- a/app/src/main/java/com/myperioddataismine/MainViewModel.kt
+++ b/app/src/main/java/com/myperioddataismine/MainViewModel.kt
@@ -4,7 +4,19 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
-    private val encryptedDatabase = (application as App).encryptedDatabase
+    private val encryptedDatabase = EncryptedDatabase(application)
+
+    fun encryptedDatabaseExists(): Boolean {
+        return encryptedDatabase.exists()
+    }
+
+    fun openDatabase(passcode: String): Boolean {
+        return encryptedDatabase.open(passcode)
+    }
+
+    fun deleteDatabase() {
+        encryptedDatabase.delete()
+    }
 
     fun getUserData(): UserData {
         return encryptedDatabase.getUserData()

--- a/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt
+++ b/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt
@@ -1,30 +1,22 @@
 package com.myperioddataismine
 
-import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 
 class PasscodeFragment : Fragment(R.layout.passcode_fragment) {
-    private lateinit var encryptedDatabase: EncryptedDatabase
     private lateinit var passcodeMessageText: TextView
     private lateinit var passcodeEditText: EditText
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        encryptedDatabase = (context.applicationContext as App).encryptedDatabase
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         passcodeMessageText = view.findViewById(R.id.passcode_message_text)
         passcodeEditText = view.findViewById(R.id.passcode_edit_text)
 
-        setMessageText()
+        setMessageText(arguments?.getString("Message"))
 
         view.findViewById<Button?>(R.id.number_0_button).setOnClickListener {
             passcodeAppend('0')
@@ -64,12 +56,8 @@ class PasscodeFragment : Fragment(R.layout.passcode_fragment) {
         }
     }
 
-    private fun setMessageText() {
-        if (encryptedDatabase.exists()) {
-            passcodeMessageText.text = resources.getString(R.string.decrypt_text)
-        } else {
-            passcodeMessageText.text = resources.getString(R.string.encrypt_text)
-        }
+    private fun setMessageText(message: String?) {
+        passcodeMessageText.text = message ?: resources.getString(R.string.decrypt_text)
     }
 
     private fun passcodeAppend(character: Char) {
@@ -83,25 +71,6 @@ class PasscodeFragment : Fragment(R.layout.passcode_fragment) {
     }
 
     private fun submit() {
-        val passcode = passcodeEditText.text.toString()
-        if (encryptedDatabase.open(passcode)) {
-            (context as MainActivity).databaseOpened()
-        } else {
-            dataErasePrompt()
-        }
-    }
-
-    private fun dataErasePrompt() {
-        context?.let {
-            AlertDialog.Builder(it)
-                .setTitle("Erase data?")
-                .setMessage("Unable to decrypt data!")
-                .setPositiveButton("Retry") { _, _ -> }
-                .setNegativeButton("Erase") { _, _ ->
-                    encryptedDatabase.delete()
-                    setMessageText()
-                }
-                .show()
-        }
+        (context as MainActivity).tryPasscode(passcodeEditText.text.toString())
     }
 }


### PR DESCRIPTION
Currently, the encrypted database can be accessed from anywhere in the application. This PR moves the encrypted database to the main activity's view model and makes it private. All access to the encrypted database is then centrally controlled via the main activity and can only be accessed via the main activity.