### PR TITLE
Cache user data in the view model

### DIFF
--- a/app/src/main/java/com/myperioddataismine/MainViewModel.kt
+++ b/app/src/main/java/com/myperioddataismine/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val encryptedDatabase = EncryptedDatabase(application)
+    private var userData: UserData? = null
 
     fun encryptedDatabaseExists(): Boolean {
         return encryptedDatabase.exists()
@@ -16,10 +17,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun deleteDatabase() {
         encryptedDatabase.delete()
+        userData = null
     }
 
     fun getUserData(): UserData {
-        return encryptedDatabase.getUserData()
+        val data = userData ?: encryptedDatabase.getUserData()
+        userData = userData ?: data
+        return data
     }
 
     fun saveUserData(userData: UserData) {


### PR DESCRIPTION
Currently, every time data is required, the data is retrieved from the database. However, the view model is designed to cache the data so that it is not necessary to retrieve the data every time the view is updated.

To improve performance, this PR caches the data in the view model. Note: The lifetime of the cached data is the lifetime of the opened, decrypted database. If the database is closed or deleted, so is the cached data.