### PR TITLE
Create build tests

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -1,0 +1,35 @@
+name: Build Tests
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_requst.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-builds:
+    name: ${{ matrix.os }} build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Gradle build
+        run: ./gradlew build
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-build-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
    <img src="my-period-data-is-mine-logo.svg" width="256" alt="My Period Data Is Mine!">
 </p>
 
+[![Build status](https://github.com/KeepDataPrivate/MyPeriodDataIsMine/actions/workflows/build-tests.yaml/badge.svg)](https://github.com/KeepDataPrivate/MyPeriodDataIsMine/actions/workflows/build-tests.yaml)
+
 Your personal data should be yours and yours only; especially if it as personal as your period data.
 
 I wouldn’t want my boss to know when I menstruate, just as I wouldn’t want to know when my neighbours have their periods. Each individual should own that information and control who they share it with and when.


### PR DESCRIPTION
Creates build tests for My Period Data Is Mine!

Ensures that all contributions are automatically tested by building the application. The tests are run on Linux, Windows and macOS to ensure that contributions are not affected by the platform used by the contributor.
Includes uploading of the debug APK created; so that contributions can be tested by anyone without requiring them to build it themselves.

Includes adding a build status badge to the README.