### PR TITLE
Add Kotlin data directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ out/
 .gradle/
 build/
 
+# Kotlin files
+.kotlin/
+
 # Local configuration file (sdk path, etc)
 local.properties
 


### PR DESCRIPTION
To avoid accidentally adding Kotlin data to the project, this PR adds the new Kotlin 2.0 `.kotlin` directory, used for storing Kotlin data[[1](https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects)], to the `.gitignore` file.

[1] https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects