### PR TITLE
Fix PR build test cancellation

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_requst.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
There is a typo in the pull request group definition that would prevent the build tests workflow from cancelling a previous build test if an update is pushed to a pull request.

This PR fixes the typo.