### PR TITLE
Migrate to Gradle Java toolchains

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,14 +25,11 @@ android {
             )
         }
     }
+}
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 


### PR DESCRIPTION
We're getting the following warning message:
```
'jvmTarget: String' is deprecated. Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln
```

We're currently using Kotlin 2.2.0. Before Kotlin 2.2.0, compiler options could be configured using the `kotlinOptions` block. Kotlin 1.8.0 introduced the `compilerOptions` block, and Kotlin 2.0.0 deprecated the `kotlinOptions` block. We need to migrate from Kotlin's `kotlinOptions` to `compilerOptions`.

We currently access the Kotlin compiler options through the `android.kotlinOptions` block. These options need to be migrated to the `kotlin.compilerOptions` block and updated to use typed values, because raw string values are no longer supported.

That been said, the only Kotlin compiler option we currently use is the Java Virtual Machine (JVM) target. Gradle version 6.7 introduced support for Java toolchains. The Android Gradle Plugin (AGP) version 7.4.0 introduced support for the Gradle Java toolchains, and, since AGP 8.1.0, uses the Gradle Java toolchain for the Android compile options too. We currently use Gradel version 8.14.2 and AGP version 8.11.1.

Therefore, this PR migrates the Android and Kotlin JVM targets to the Gradle's Java toolchain that is used by both Kotlin and Android.

References:
[1] https://kotlinlang.org/docs/gradle-compiler-options.html
[2] https://kotlinlang.org/docs/gradle-configure-project.html
[3] https://docs.gradle.org/current/userguide/toolchains.html