### PR TITLE
Don't cancel build tests running on the main branch

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: build-test-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   android-builds:


### PR DESCRIPTION
The build tests that ran when merging pull request [31](https://github.com/KeepDataPrivate/MyPeriodDataIsMine/commit/02a2695a77f51ed2128df1bd7616c378851c7027) failed, because they were cancelled when merging pull request [30](https://github.com/KeepDataPrivate/MyPeriodDataIsMine/commit/6a6b3f90dbc21f660b5d16a92cdf20bb1a890a92).

Currently, if a branch or a pull request is updated, to save time and resources, in progress build tests are cancelled and a new build test is started. However, for updates to the `main` branch, we want all build tests to run to completion. Specifically, when merging multiple pull requests, we want to test all merges. We do not want a new merge to cancel tests running on a previous merge.

Since the only way to update the `main` branch is through merging a pull request, this PR ensures that all updates to the `main` do not cancel in progress build tests.