### PR TITLE
Fix findViewById returning a nullable type

### DIFF
--- a/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt
+++ b/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt
@@ -18,40 +18,40 @@ class PasscodeFragment : Fragment(R.layout.passcode_fragment) {
 
         setMessageText(arguments?.getString("Message"))
 
-        view.findViewById<Button?>(R.id.number_0_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_0_button).setOnClickListener {
             passcodeAppend('0')
         }
-        view.findViewById<Button?>(R.id.number_1_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_1_button).setOnClickListener {
             passcodeAppend('1')
         }
-        view.findViewById<Button?>(R.id.number_2_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_2_button).setOnClickListener {
             passcodeAppend('2')
         }
-        view.findViewById<Button?>(R.id.number_3_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_3_button).setOnClickListener {
             passcodeAppend('3')
         }
-        view.findViewById<Button?>(R.id.number_4_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_4_button).setOnClickListener {
             passcodeAppend('4')
         }
-        view.findViewById<Button?>(R.id.number_5_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_5_button).setOnClickListener {
             passcodeAppend('5')
         }
-        view.findViewById<Button?>(R.id.number_6_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_6_button).setOnClickListener {
             passcodeAppend('6')
         }
-        view.findViewById<Button?>(R.id.number_7_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_7_button).setOnClickListener {
             passcodeAppend('7')
         }
-        view.findViewById<Button?>(R.id.number_8_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_8_button).setOnClickListener {
             passcodeAppend('8')
         }
-        view.findViewById<Button?>(R.id.number_9_button).setOnClickListener {
+        view.findViewById<Button>(R.id.number_9_button).setOnClickListener {
             passcodeAppend('9')
         }
-        view.findViewById<Button?>(R.id.del_button).setOnClickListener {
+        view.findViewById<Button>(R.id.del_button).setOnClickListener {
             passcodeDrop()
         }
-        view.findViewById<Button?>(R.id.ok_button).setOnClickListener {
+        view.findViewById<Button>(R.id.ok_button).setOnClickListener {
             submit()
         }
     }

--- a/app/src/main/java/com/myperioddataismine/WelcomeFragment.kt
+++ b/app/src/main/java/com/myperioddataismine/WelcomeFragment.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.Fragment
 class WelcomeFragment : Fragment(R.layout.welcome_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Button?>(R.id.get_started_button).setOnClickListener {
+        view.findViewById<Button>(R.id.get_started_button).setOnClickListener {
             (context as MainActivity).getStarted()
         }
     }


### PR DESCRIPTION
We're getting the following compiler warnings messages:
```
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:21:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:24:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:27:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:30:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:33:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:36:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:39:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:42:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:45:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:48:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:51:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/PasscodeFragment.kt:54:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
w: file:///home/runner/work/MyPeriodDataIsMine/MyPeriodDataIsMine/app/src/main/java/com/myperioddataismine/WelcomeFragment.kt:11:9 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'Button?'. This will become an error in language version 2.3. See https://youtrack.jetbrains.com/issue/KT-71718.
```
These are caused by `[View](https://developer.android.com/reference/android/view/View)`'s templated `[findViewById()](https://developer.android.com/reference/android/view/View#findViewById(int))` methods being called with a nullable template type.

This PR converts the nullable template type `findViewById()` calls to non-nullable template types.