### PR TITLE
Treat all warnings as errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,12 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
+}
+
 dependencies {
     implementation(libs.android.material)
     implementation(libs.androidx.appcompat)


### PR DESCRIPTION
When we upgraded to use Kotlin 2.2.0, the build tests raised new warnings (identified and fixed #37). By default the build tests will pass if there are no errors, because warnings are not treated as errors. However, to ensure we always have the best code, we should treat all warnings as errors. This will ensure that any potential issues are identified and addressed as soon as possible.

This PR updates the Kotlin compiler options to treat all warnings as errors.