### PR TITLE
Add default toolchain download repository plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
My Period Data Is Mine! currently depends on [JDK 17](https://openjdk.org/projects/jdk/17/). If an implementation of the JDK is not installed, the build will fail with the following message:
```
A build operation failed.
    Could not create task ':app:compileDebugAndroidTestJavaWithJavac'.
Could not create task ':app:compileDebugAndroidTestJavaWithJavac'.
Failed to calculate the value of task ':app:compileDebugAndroidTestJavaWithJavac' property 'javaCompiler'.
Cannot find a Java installation on your machine (**************) matching: {languageVersion=17, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. Toolchain download repositories have not been configured.

Possible solution:
 - Add default toolchain download repository plugin
```

[Foojay](https://foojay.io/) (Friends of OpenJDK) provides a Universal OpenJDK Discovery API ([Disco API)](https://github.com/foojayio/discoapi). The [foojay-toolchains plugin](https://github.com/gradle/foojay-toolchains) is a Gradle settings plugin that provides automatic JDK provisioning through integration with the Foojay DiscoAPI. It eliminates the need to manually install Java toolchains by automatically downloading the appropriate JDK based on toolchain specifications defined in build scripts.[[1](https://deepwiki.com/gradle/foojay-toolchains)]

This PR adds the foojay-toolchains settings convention plugin to automatically download an OpenJDK implementation of the required JDK if one is not installed.

References:
1. https://deepwiki.com/gradle/foojay-toolchains