### PR TITLE
Update the minimum SDK from 21 to 23

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.myperioddataismine"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
Some of the libraries we use have been updated to use a minimum SDK of 23. Specifically, the latest version of the [AndroidX SQLite](https://developer.android.com/jetpack/androidx/releases/sqlite) library [v2.6.0](https://developer.android.com/jetpack/androidx/releases/sqlite#2.6.0). See https://github.com/KeepDataPrivate/MyPeriodDataIsMine/pull/47#issuecomment-3292341056.

The 10<sup>th</sup> September 2025 release of the AndroidX  Jetpack libraries release notes[[1](https://developer.android.com/jetpack/androidx/versions/all-channel)] state:
> Note: Starting in June 2025, new releases of many AndroidX libraries previously targeting minSdk 21 will be updated to require minSdk 23. Some libraries won't be re-released and will therefore continue to support minSdk 21.

[AndroidX](https://developer.android.com/jetpack/androidx/) libraries provide backward compatibility for new Android features across Android releases. However, the backward compatibility is limited to supporting 99% of devices. As identified in issue 380448311[[2](https://issuetracker.google.com/issues/380448311)]:
> As of 9/1/2024 data from Play Store users as shown in Android Studio, API 23+ accounts for 99.1% of users, API 24+ is 98.0% of users. Our desired support level is 99%, so we'll be picking API 23 as our next minSdk version.

API 21 is supported by all Android 5 (a.k.a. [Android Lollipop](https://en.wikipedia.org/wiki/Android_Lollipop)) devices and newer. API 23 is supported by all Android 6 (a.k.a. [Android Marshmallow](https://en.wikipedia.org/wiki/Android_Marshmallow)) devices and newer[[3](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels)]. Android Lollipop was released in November 2014. Android Marshmallow was released in September 2015[[4](https://en.wikipedia.org/wiki/Android_version_history)]. Therefore, increasing the minimum SDK supported from 21 to 23 will only affect devices released between these dates 10 and 11 years ago!

Although increasing the minimum SDK will reduce the number of users that can use My Period Data Is Mine!, the creators of the AndroidX libraries indicate that this will be insignificant. To enable us to continue to receive the latest updates to the AndroidX libraries, and to keep My Period Data Is Mine! as secure and stable as possible for the vast majority of our users,  this PR updates the My Period Data Is Mine! minimum SDK to 23 too.

References:
1. https://developer.android.com/jetpack/androidx/versions/all-channel
2. https://issuetracker.google.com/issues/380448311
3. https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels
4. https://en.wikipedia.org/wiki/Android_version_history