### PR TITLE
Remove the manual set up of Java 17 from the build tests

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -19,12 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: zulu
-          java-version: 17
-
       - name: Gradle build
         run: ./gradlew build
 


### PR DESCRIPTION
#48 removes the need to configure the required JDK manually.

This PR removes the manual configuration of the JDK from our build tests.