### PR TITLE
Place the cancel button to the left of the save button

### DIFF
--- a/app/src/main/res/layout/save_cancel_buttons.xml
+++ b/app/src/main/res/layout/save_cancel_buttons.xml
@@ -7,17 +7,17 @@
     android:gravity="center"
 >
     <Button
-        android:id="@+id/save_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="10dp"
-        android:text="@string/save"
-    />
-    <Button
         android:id="@+id/cancel_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         android:text="@string/cancel"
+    />
+    <Button
+        android:id="@+id/save_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:text="@string/save"
     />
 </LinearLayout>


### PR DESCRIPTION
According to [Material Design 3](https://m3.material.io/), Google’s open-source design system, the button for the dismissive action should be to the left of the button for the confirming action. [[1](https://m3.material.io/components/dialogs/guidelines)]. In our case the `Cancel` button should be to the left of the `Save` button.

> **Buttons** 
>
> Dialog actions are most often represented as buttons and allow users to confirm, dismiss, or acknowledge something.
>
> Buttons are aligned to the trailing edge of the dialog for easier interaction. The confirmation button is always closest to the edge. 
>
> Button alignment responds automatically for right-to-left languages, where the confirmation button is aligned to the left edge.
>
> Disable confirming actions until a choice is made. Dismissive actions are never disabled.
>
> Don’t place dismissive actions to the right of confirming actions. Instead, place them to the left of confirming actions.

Reference:
[1] https://m3.material.io/components/dialogs/guidelines
