### PR TITLE
Use property access syntax for hiding menu item

### DIFF
--- a/app/src/main/kotlin/com/myperioddataismine/MainActivity.kt
+++ b/app/src/main/kotlin/com/myperioddataismine/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
         val inflater: MenuInflater = menuInflater
         inflater.inflate(R.menu.main_menu, menu)
         if (!viewModel.decryptedDatabaseIsOpen()) {
-            menu.findItem(R.id.change_passcode).setVisible(false)
+            menu.findItem(R.id.change_passcode).isVisible = false
         }
         return true
     }


### PR DESCRIPTION
Uses the recommended, more intuitive property access syntax instead of a setter method when hiding a menu item.
