### PR TITLE
Don't use multi-ecosystem-groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,7 @@
 version: 2
-multi-ecosystem-groups:
-  weekly-updates:
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -9,21 +10,21 @@ multi-ecosystem-groups:
       - "PR Type: Maintenance"
     pull-request-branch-name:
       separator: "-"
-    groups:
-      version-updates:
-          patterns:
-             - "*"
-          update-types:
-            - "minor"
-            - "patch"
-
-updates:
-  - package-ecosystem: "github-actions"
-    multi-ecosystem-group: "weekly-updates"
-    patterns: ["*"]
-    directory: "/"
 
   - package-ecosystem: "gradle"
-    multi-ecosystem-group: "weekly-updates"
-    patterns: ["*"]
     directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "01:00"
+    labels:
+      - "PR Type: Maintenance"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      version-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
#56 updated [dependabot](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide) to use `multi-ecosystem-groups`. Using `multi-ecosystem-groups` reduced the number of update pull requests created by grouping all updates across ecosystems. However, we lost the ability to only group updates that do not involve major updates.

This PR reverts #56. Therefore updates from different ecosystems i.e. [Github Actions](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions) and [Gradle](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#gradle) will be in separate updates. Updates within an ecosystem that do not include a major update will be grouped together.

**Note:** Updates within the Github Actions ecosystem are always major updates; so they will never be grouped together.