### PR TITLE
Use module instead of group and name when specifying libraries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ android-material = { module = 'com.google.android.material:material', version.re
 androidx-appcompat = { module = 'androidx.appcompat:appcompat', version.ref = 'androidx-appcompat' }
 androidx-core-ktx = { module = 'androidx.core:core-ktx', version.ref = 'androidx-core-ktx' }
 androidx-fragment-ktx = { module = 'androidx.fragment:fragment-ktx', version.ref = 'androidx-fragment-ktx' }
-androidx-lifecycle-viewmodel-ktx = { group = 'androidx.lifecycle', name = 'lifecycle-viewmodel-ktx', version.ref = 'androidx-lifecycle-viewmodel-ktx' }
-androidx-sqlite = { group = 'androidx.sqlite', name = 'sqlite', version.ref = 'androidx-sqlite' }
-google-flexbox = { group = 'com.google.android.flexbox', name = 'flexbox', version.ref = 'google-flexbox'}
-sqlcipher = { group = 'net.zetetic', name = 'sqlcipher-android', version.ref = 'sqlcipher' }
+androidx-lifecycle-viewmodel-ktx = { module = 'androidx.lifecycle:lifecycle-viewmodel-ktx', version.ref = 'androidx-lifecycle-viewmodel-ktx' }
+androidx-sqlite = { module = 'androidx.sqlite:sqlite', version.ref = 'androidx-sqlite' }
+google-flexbox = { module = 'com.google.android.flexbox:flexbox', version.ref = 'google-flexbox'}
+sqlcipher = { module = 'net.zetetic:sqlcipher-android', version.ref = 'sqlcipher' }


### PR DESCRIPTION
When specifying dependency libraries, both `group` with `name` and `module` are equivalent. For consistency, we should use one. This PR uses `module` for specifying all dependency libraries, for no other reason than it's shorter.